### PR TITLE
remove the restriction for remote run should take the sender operator as the last operator.

### DIFF
--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -60,7 +60,8 @@ func (s *Scope) remoteRun(c *Compile) (sender *messageSenderOnClient, err error)
 
 	// encode structures which need to send.
 	var scopeEncodeData, processEncodeData []byte
-	scopeEncodeData, processEncodeData, err = prepareRemoteRunSendingData(c.sql, s)
+	var withoutOutput bool
+	scopeEncodeData, withoutOutput, processEncodeData, err = prepareRemoteRunSendingData(c.sql, s)
 	if err != nil {
 		return nil, err
 	}
@@ -80,95 +81,88 @@ func (s *Scope) remoteRun(c *Compile) (sender *messageSenderOnClient, err error)
 		return nil, err
 	}
 
-	if err = sender.sendPipeline(scopeEncodeData, processEncodeData); err != nil {
+	if err = sender.sendPipeline(scopeEncodeData, processEncodeData, withoutOutput); err != nil {
 		return sender, err
 	}
 
 	sender.safeToClose = false
 	sender.alreadyClose = false
-	err = receiveMessageFromCnServer(c, s, sender)
+	err = receiveMessageFromCnServer(s, withoutOutput, sender)
 	return sender, err
 }
 
-func prepareRemoteRunSendingData(sqlStr string, s *Scope) (scopeData []byte, processData []byte, err error) {
-	// 1.
-	// Encode the Scope related.
-	// encode all operators in the scope except the last one.
-	// because we need to keep it local for receiving and sending batch to next pipeline.
-	rootOp := s.RootOp
-	if rootOp.GetOperatorBase().NumChildren() == 0 {
-		s.RootOp = nil
-	} else {
-		s.RootOp = s.RootOp.GetOperatorBase().GetChildren(0)
-	}
-	rootOp.GetOperatorBase().SetChildren(nil)
-	defer func() {
-		s.doSetRootOperator(rootOp)
-	}()
+func prepareRemoteRunSendingData(sqlStr string, s *Scope) (scopeData []byte, withoutOutput bool, processData []byte, err error) {
+	// if simpleRun is true, it indicates that this pipeline will not produce any output.
+	withoutOutput = false
 
-	if scopeData, err = encodeScope(s); err != nil {
-		return nil, nil, err
-	}
-
-	// 2.
-	// Encode the Process related information.
-	if processData, err = encodeProcessInfo(s.Proc, sqlStr); err != nil {
-		return nil, nil, err
-	}
-
-	return scopeData, processData, nil
-}
-
-func receiveMessageFromCnServer(c *Compile, s *Scope, sender *messageSenderOnClient) error {
-	// if the last operator was connector,
-	// we can send data to the receiver channel to reduce spool's copy.
-	if _, isConnector := s.RootOp.(*connector.Connector); isConnector {
-		return receiveMessageFromCnServerIfConnector(s, sender)
-	}
-
-	// generate a new pipeline to send data in local.
-	// value_scan -> dispatch -> next pipeline.
-	if arg, isDispatch := s.RootOp.(*dispatch.Dispatch); isDispatch {
-		fakeValueScanOperator := value_scan.NewValueScanFromItSelf()
-		if err := fakeValueScanOperator.Prepare(s.Proc); err != nil {
-			return err
-		}
-
-		oldChildren := arg.Children
-		arg.Children = nil
-		arg.AppendChild(fakeValueScanOperator)
+	// if the last operator is a sender operator, we need to keep it in local for sending batch to its receivers correctly.
+	if lastOpType := s.RootOp.OpType(); lastOpType == vm.Connector || lastOpType == vm.Dispatch {
+		originRoot := s.RootOp
+		withoutOutput = true
 		defer func() {
-			arg.Children = oldChildren
-			fakeValueScanOperator.Release()
+			s.doSetRootOperator(originRoot)
 		}()
 
-		if err := s.RootOp.Prepare(s.Proc); err != nil {
-			return err
-		}
-
-		var bat *batch.Batch
-		var end bool
-		var err error
-		dispatchAnalyze := s.RootOp.GetOperatorBase().OpAnalyzer
-
-		for {
-			bat, end, err = sender.receiveBatch()
-			if err != nil || end || bat == nil {
-				return err
-			}
-
-			dispatchAnalyze.Network(bat)
-			fakeValueScanOperator.Batchs = append(fakeValueScanOperator.Batchs, bat)
-
-			result, errCall := s.RootOp.Call(s.Proc)
-			bat.Clean(c.proc.GetMPool())
-			if errCall != nil || result.Status == vm.ExecStop {
-				return errCall
-			}
+		if originRoot.GetOperatorBase().NumChildren() == 0 {
+			s.RootOp = nil
+		} else {
+			s.RootOp = originRoot.GetOperatorBase().GetChildren(0)
 		}
 	}
 
-	panic(fmt.Sprintf("remote run pipeline has an unexpected operator [id = %d] at last.", s.RootOp.OpType()))
+	// Encode the ScopeList which need to be sent.
+	if scopeData, err = encodeScope(s); err != nil {
+		return nil, false, nil, err
+	}
+
+	// Encode the Process related information.
+	if processData, err = encodeProcessInfo(s.Proc, sqlStr); err != nil {
+		return nil, false, nil, err
+	}
+
+	return scopeData, withoutOutput, processData, nil
+}
+
+func receiveMessageFromCnServer(s *Scope, withoutOutput bool, sender *messageSenderOnClient) error {
+	if !withoutOutput {
+		// if the last operator was connector,
+		// we can send data to the receiver channel to reduce spool's copy.
+		if _, isConnector := s.RootOp.(*connector.Connector); isConnector {
+			return receiveMessageFromCnServerIfConnector(s, sender)
+		}
+
+		// generate a new pipeline to send data in local.
+		// value_scan -> dispatch -> next pipeline.
+		if _, isDispatch := s.RootOp.(*dispatch.Dispatch); isDispatch {
+			return receiveMessageFromCnServerIfDispatch(s, sender)
+		}
+
+		panic(fmt.Sprintf("remote run pipeline has an unexpected operator [id = %d] at last.", s.RootOp.OpType()))
+	}
+
+	// if the last operator is neither a connector nor a dispatch,
+	// this indicates that it is a pipeline that does not require any local cooperation;
+	// we simply need to wait for the remote execution to finish.
+	return receiveMessageFromCnServerIfOnlyRun(s, sender)
+}
+
+func receiveMessageFromCnServerIfOnlyRun(s *Scope, sender *messageSenderOnClient) error {
+	var bat *batch.Batch
+	var end bool
+	var err error
+
+	mp := s.Proc.Mp()
+	// Waiting the EndMessage or ErrorMessage.
+	// In fact, for a pipeline that only needs to be executed remotely but without sending data back,
+	// there should be no message sent back except for EndMessage or ErrorMessage.
+	// However, I have used a loop here to ensure that the query can still be executed normally even if this situation occurs.
+	for {
+		bat, end, err = sender.receiveBatch()
+		if err != nil || end || bat == nil {
+			return err
+		}
+		bat.Clean(mp)
+	}
 }
 
 func receiveMessageFromCnServerIfConnector(s *Scope, sender *messageSenderOnClient) error {
@@ -190,6 +184,48 @@ func receiveMessageFromCnServerIfConnector(s *Scope, sender *messageSenderOnClie
 		connectorAnalyze.Network(bat)
 
 		nextChannel <- process.NewPipelineSignalToDirectly(bat, mp)
+	}
+}
+
+func receiveMessageFromCnServerIfDispatch(s *Scope, sender *messageSenderOnClient) error {
+	var bat *batch.Batch
+	var end bool
+	var err error
+
+	arg := s.RootOp.(*dispatch.Dispatch)
+	fakeValueScanOperator := value_scan.NewValueScanFromItSelf()
+	if err := fakeValueScanOperator.Prepare(s.Proc); err != nil {
+		return err
+	}
+
+	oldChildren := arg.Children
+	arg.Children = nil
+	arg.AppendChild(fakeValueScanOperator)
+	defer func() {
+		arg.Children = oldChildren
+		fakeValueScanOperator.Release()
+	}()
+
+	if err = s.RootOp.Prepare(s.Proc); err != nil {
+		return err
+	}
+	dispatchAnalyze := s.RootOp.GetOperatorBase().OpAnalyzer
+
+	mp := s.Proc.Mp()
+	for {
+		bat, end, err = sender.receiveBatch()
+		if err != nil || end || bat == nil {
+			return err
+		}
+
+		dispatchAnalyze.Network(bat)
+		fakeValueScanOperator.Batchs = append(fakeValueScanOperator.Batchs, bat)
+
+		result, errCall := s.RootOp.Call(s.Proc)
+		bat.Clean(mp)
+		if errCall != nil || result.Status == vm.ExecStop {
+			return errCall
+		}
 	}
 }
 
@@ -256,7 +292,7 @@ func newMessageSenderOnClient(
 }
 
 func (sender *messageSenderOnClient) sendPipeline(
-	scopeData, procData []byte) error {
+	scopeData, procData []byte, noDataBack bool) error {
 	sdLen := len(scopeData)
 	if sdLen <= maxMessageSizeToMoRpc {
 		message := cnclient.AcquireMessage()
@@ -265,7 +301,7 @@ func (sender *messageSenderOnClient) sendPipeline(
 		message.SetData(scopeData)
 		message.SetProcData(procData)
 		message.SetSid(pipeline.Status_Last)
-		message.NeedNotReply = false
+		message.NeedNotReply = noDataBack
 		return sender.streamSender.Send(sender.ctx, message)
 	}
 
@@ -284,7 +320,7 @@ func (sender *messageSenderOnClient) sendPipeline(
 			message.SetData(scopeData[start:end])
 			message.SetSid(pipeline.Status_WaitingNext)
 		}
-		message.NeedNotReply = false
+		message.NeedNotReply = noDataBack
 
 		if err := sender.streamSender.Send(sender.ctx, message); err != nil {
 			return err
@@ -409,7 +445,7 @@ func generateStopSendingMessage(streamID uint64) *pipeline.Message {
 	message := cnclient.AcquireMessage()
 	message.SetMessageType(pipeline.Method_StopSending)
 	message.SetID(streamID)
-	message.NeedNotReply = true
+	message.NeedNotReply = false
 	return message
 }
 

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -96,10 +96,10 @@ func CnServerMessageHandler(
 		cs, messageAcquirer, storageEngine, fileService, lockService, queryClient, HaKeeper, udfService, txnClient, autoIncreaseCM)
 
 	// how to handle the *pipeline.Message.
-	if receiver.needNotReply {
-		err = handlePipelineMessage(&receiver)
-	} else {
-		if err = handlePipelineMessage(&receiver); err != nil {
+	err = handlePipelineMessage(&receiver)
+	if receiver.messageTyp != pipeline.Method_StopSending {
+		// stop message only close a running pipeline, there is no need to reply the finished-message.
+		if err != nil {
 			err = receiver.sendError(err)
 		} else {
 			err = receiver.sendEndMessage()
@@ -178,7 +178,9 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 		if err != nil {
 			return err
 		}
-		s = appendWriteBackOperator(runCompile, s)
+		if !receiver.needNotReply {
+			s = appendWriteBackOperator(runCompile, s)
+		}
 
 		runCompile.scopes = []*Scope{s}
 		runCompile.InitPipelineContextToExecuteQuery()

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -339,16 +339,12 @@ func (s *Scope) RemoteRun(c *Compile) error {
 	sender, err := s.remoteRun(c)
 
 	runErr := err
-	select {
-	case <-s.Proc.Ctx.Done():
-		// this clean-up action shouldn't be called before context check.
-		// because the clean-up action will cancel the context, and error will be suppressed.
-		p.CleanRootOperator(s.Proc, err != nil, c.isPrepare, err)
+	if s.Proc.Ctx.Err() != nil {
 		runErr = nil
-
-	default:
-		p.CleanRootOperator(s.Proc, err != nil, c.isPrepare, err)
 	}
+	// this clean-up action shouldn't be called before context check.
+	// because the clean-up action will cancel the context, and error will be suppressed.
+	p.CleanRootOperator(s.Proc, err != nil, c.isPrepare, err)
 
 	// sender should be closed after cleanup (tell the children-pipeline that query was done).
 	if sender != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
1. 去除remote run必须以dispatch / connector算子为结尾的限制。
2. 重定义pipeline message中NeedNotReply为该pipeline是否需要发除end message以外的消息回来。
3. 提高remote run代码可读性。